### PR TITLE
Add rel="me" to verify Mastodon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<p align="center">
+  <img width="250" height="250" 
+       src="https://raw.githubusercontent.com/helsinki-python/logo/main/HelPy.svg" 
+       alt="Helsinki Python logo">
+</p>
+
 # helsinki-python.github.io
+
+https://helsinki-python.github.io
 
 ## Building
 
@@ -9,4 +17,4 @@ make # this will serve on http://localhost:4000
 
 ## Deploying
 
-Commit, push and wait for Github actions.
+Commit, push and wait for GitHub Actions.

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ region meeting up roughly every month.
 
 - [Join on meetup.com](https://www.meetup.com/helpy-meetups/)
 - [Propose a talk](https://forms.gle/KjZVgeMGHRd5ECCJ9)
-- Follow [on Mastodon](https://fosstodon.org/@HelPy)
+- Follow <a rel="me" href="https://fosstodon.org/@HelPy">on Mastodon</a>
 
 ### Organisers
 


### PR DESCRIPTION
If we add `rel="me"` to the Mastodon link, then the link back to _here_ from the Mastodon profile will appear verified.

See: 

* https://fosstodon.org/@pillow for examples
* https://joinmastodon.org/verification
* https://fosstodon.org/settings/verification

Also add logo and link to README.